### PR TITLE
adding reverse openai gym wrapper and tests

### DIFF
--- a/bsuite/utils/gym_wrapper.py
+++ b/bsuite/utils/gym_wrapper.py
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -59,6 +59,7 @@ class GymWrapper(gym.Env):
     if mode == 'human':
       if self.viewer is None:
         from gym.envs.classic_control import rendering  # pylint: disable=g-import-not-at-top
+
         self.viewer = rendering.SimpleImageViewer()
       self.viewer.imshow(self._last_observation)
       return self.viewer.isopen
@@ -93,3 +94,77 @@ class GymWrapper(gym.Env):
   def __getattr__(self, attr):
     """Delegate attribute access to underlying environment."""
     return getattr(self._env, attr)
+
+
+class ReverseGymWrapper(dm_env.Environment):
+    """A wrapper that converts an OpenAI gym environment to a dm_env.Environment"""
+
+    def __init__(self, gym_env:gym.Env):
+        self.gym_env = gym_env
+        # convert gym action and observation spaces to dm_env specs
+        self._observation_spec = self.space2spec(self.gym_env.observation_space, "observations")
+        self._action_spec = self.space2spec(self.gym_env.action_space, "actions")
+
+    def reset(self):
+        self.gym_env.reset()
+
+    def step(self, action):
+        """convert gym step result (observations, reward, done, info) to dm_env TimeStep"""
+        gym_step_res = self.gym_env.step(action)
+        _obs = gym_step_res[0]
+        _reward = gym_step_res[1]
+        _done = gym_step_res[2]
+
+        if _done:
+            return dm_env.TimeStep(dm_env.StepType.LAST, _reward, None, _obs)
+        else:
+            return dm_env.TimeStep(dm_env.StepType.MID, _reward, None, _obs)
+
+    def close(self):
+        self.gym_env.close()
+
+    def observation_spec(self):
+        return self._observation_spec
+
+    def action_spec(self):
+        return self._action_spec
+
+    def space2spec(self, space:gym.Space, name:str=None):
+        """convert a gym space to a dm_env spec.
+
+        Box, MultiBinary and MultiDiscrete openai spaces are converted to BoundedArray specs.  Discrete openai
+        spaces are converted to DiscreteArray specs.  Tuple and Dict spaces are recursively converted to tuples
+        and dictionaries of specs.
+        """
+        if isinstance(space, spaces.Discrete):
+            return specs.DiscreteArray(num_values=space.n, dtype=space.dtype, name=name)
+
+        elif isinstance(space, spaces.Box):
+            return specs.BoundedArray(shape=space.shape, dtype=space.dtype, minimum=space.low, maximum=space.high,
+                                      name=name)
+
+        elif isinstance(space, spaces.MultiBinary):
+            return specs.BoundedArray(shape=space.shape, dtype=space.dtype, minimum=0.0, maximum=1.0, name=name)
+
+        elif isinstance(space, spaces.MultiDiscrete):
+            return specs.BoundedArray(shape=space.shape, dtype=space.dtype, minimum=np.zeros(space.shape),
+                                      maximum=space.nvec, name=name)
+
+        elif isinstance(space, spaces.Tuple):
+
+            spec_list = []
+            for _space in space.spaces:
+                spec_list.append(self.space2spec(_space, name))
+
+            return tuple(spec_list)
+
+        elif isinstance(space, spaces.Dict):
+
+            spec_dict = {}
+            for k in space.spaces:
+                spec_dict[k] = self.space2spec(space.spaces[k], name)
+
+            return spec_dict
+
+        else:
+            raise ValueError("Unexpected gym space type")

--- a/bsuite/utils/wrappers_test.py
+++ b/bsuite/utils/wrappers_test.py
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,15 +21,16 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 from bsuite.experiments.catch import catch
-from bsuite.utils import wrappers
 from bsuite.utils import gym_wrapper
+from bsuite.utils import wrappers
 
 import dm_env
 from dm_env import specs
 from dm_env import test_utils
+import gym
 import mock
 import numpy as np
-import gym
+
 
 class FakeEnvironment(dm_env.Environment):
   """An environment that returns pre-determined rewards and observations."""
@@ -141,29 +142,29 @@ class ImageWrapperCatchTest(test_utils.EnvironmentTestMixin, absltest.TestCase):
 class ReverseGymWrapperTest(absltest.TestCase):
 
   def test_gym_cartpole(self):
-    self.gym_test_env = gym_wrapper.ReverseGymWrapper(gym.make('CartPole-v0'))
+    gym_test_env = gym_wrapper.ReverseGymWrapper(gym.make('CartPole-v0'))
 
     # test converted observation spec
-    self.assertEqual(type(self.gym_test_env.observation_spec()), specs.BoundedArray)
-    self.assertEqual(self.gym_test_env.observation_spec().shape,(4,))
-    self.assertEqual(self.gym_test_env.observation_spec().minimum.shape, (4,))
-    self.assertEqual(self.gym_test_env.observation_spec().maximum.shape, (4,))
-    self.assertEqual(self.gym_test_env.observation_spec().dtype,np.dtype('float32'))
+    self.assertEqual(type(gym_test_env.observation_spec()), specs.BoundedArray)
+    self.assertEqual(gym_test_env.observation_spec().shape, (4,))
+    self.assertEqual(gym_test_env.observation_spec().minimum.shape, (4,))
+    self.assertEqual(gym_test_env.observation_spec().maximum.shape, (4,))
+    self.assertEqual(gym_test_env.observation_spec().dtype, np.dtype('float32'))
 
     #test converted action spec
-    self.assertEqual(type(self.gym_test_env.action_spec()), specs.DiscreteArray)
-    self.assertEqual(self.gym_test_env.action_spec().shape,())
-    self.assertEqual(self.gym_test_env.action_spec().minimum,0)
-    self.assertEqual(self.gym_test_env.action_spec().maximum,1)
-    self.assertEqual(self.gym_test_env.action_spec().num_values,2)
-    self.assertEqual(self.gym_test_env.action_spec().dtype,np.dtype('int64'))
+    self.assertEqual(type(gym_test_env.action_spec()), specs.DiscreteArray)
+    self.assertEqual(gym_test_env.action_spec().shape, ())
+    self.assertEqual(gym_test_env.action_spec().minimum, 0)
+    self.assertEqual(gym_test_env.action_spec().maximum, 1)
+    self.assertEqual(gym_test_env.action_spec().num_values, 2)
+    self.assertEqual(gym_test_env.action_spec().dtype, np.dtype('int64'))
 
     #test step
-    self.gym_test_env.reset()
-    test_timestep = self.gym_test_env.step(1)
-    self.assertEqual(test_timestep.reward,1.0)
-    self.assertEqual(test_timestep.observation.shape,(4,))
-    self.gym_test_env.close()
+    gym_test_env.reset()
+    test_timestep = gym_test_env.step(1)
+    self.assertEqual(test_timestep.reward, 1.0)
+    self.assertEqual(test_timestep.observation.shape, (4,))
+    gym_test_env.close()
 
 
 if __name__ == '__main__':

--- a/bsuite/utils/wrappers_test.py
+++ b/bsuite/utils/wrappers_test.py
@@ -22,13 +22,14 @@ from absl.testing import parameterized
 
 from bsuite.experiments.catch import catch
 from bsuite.utils import wrappers
+from bsuite.utils import gym_wrapper
 
 import dm_env
 from dm_env import specs
 from dm_env import test_utils
 import mock
 import numpy as np
-
+import gym
 
 class FakeEnvironment(dm_env.Environment):
   """An environment that returns pre-determined rewards and observations."""
@@ -135,6 +136,34 @@ class ImageWrapperCatchTest(test_utils.EnvironmentTestMixin, absltest.TestCase):
 
     for _ in range(100):
       yield rng.choice(actions)
+
+
+class ReverseGymWrapperTest(absltest.TestCase):
+
+  def test_gym_cartpole(self):
+    self.gym_test_env = gym_wrapper.ReverseGymWrapper(gym.make('CartPole-v0'))
+
+    # test converted observation spec
+    self.assertEqual(type(self.gym_test_env.observation_spec()), specs.BoundedArray)
+    self.assertEqual(self.gym_test_env.observation_spec().shape,(4,))
+    self.assertEqual(self.gym_test_env.observation_spec().minimum.shape, (4,))
+    self.assertEqual(self.gym_test_env.observation_spec().maximum.shape, (4,))
+    self.assertEqual(self.gym_test_env.observation_spec().dtype,np.dtype('float32'))
+
+    #test converted action spec
+    self.assertEqual(type(self.gym_test_env.action_spec()), specs.DiscreteArray)
+    self.assertEqual(self.gym_test_env.action_spec().shape,())
+    self.assertEqual(self.gym_test_env.action_spec().minimum,0)
+    self.assertEqual(self.gym_test_env.action_spec().maximum,1)
+    self.assertEqual(self.gym_test_env.action_spec().num_values,2)
+    self.assertEqual(self.gym_test_env.action_spec().dtype,np.dtype('int64'))
+
+    #test step
+    self.gym_test_env.reset()
+    test_timestep = self.gym_test_env.step(1)
+    self.assertEqual(test_timestep.reward,1.0)
+    self.assertEqual(test_timestep.observation.shape,(4,))
+    self.gym_test_env.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR is related to https://github.com/deepmind/bsuite/issues/6 where I suggested a wrapper that converts Openai gym environments to bsuite environments. This PR contains the wrapper and a test case that converts the Openai CartPole-v0 environment to a bsuite environment.