### PR TITLE
Fix bsuite datasets.py reshape bug.

### DIFF
--- a/bsuite/utils/datasets.py
+++ b/bsuite/utils/datasets.py
@@ -54,7 +54,7 @@ def load_mnist(directory="/tmp/mnist"):
     with gzip.open(filename, "rb") as fh:
       _, num_data, rows, cols = struct.unpack(">IIII", fh.read(16))
       return np.array(array.array("B", fh.read()),
-                      dtype=np.int8).reshape(shape=(num_data, rows, cols))
+                      dtype=np.int8).reshape((num_data, rows, cols))
 
   for filename in ["train-images-idx3-ubyte.gz", "train-labels-idx1-ubyte.gz",
                    "t10k-images-idx3-ubyte.gz", "t10k-labels-idx1-ubyte.gz"]:


### PR DESCRIPTION
In the datasets.py parse_images function, the ndarray reshape method is used
with a shape= keyword parameter.  This keyword param isn't valid
(the reshape method appears to only accept positional args for shape).
As a result, the baseline agents' run_test.py tests fail on the MNIST test,
when the parse_images function is called.  This can be reproduced in a clean
repo by pip installing the dependencies, cd bsuite/baselines/random, and
running python3 run_test.py .

This commit just removes the shape= keyword to pass the shape as a
positional argument, after which the agents' run_test.py tests succeed.