### PR TITLE
threadlimit

### DIFF
--- a/bsuite/baselines/utils/pool.py
+++ b/bsuite/baselines/utils/pool.py
@@ -22,8 +22,16 @@ from typing import Callable, Optional, Sequence
 
 import termcolor
 import tqdm
+import threadpoolctl
 
 BsuiteId = str
+
+
+def thread_limit_run_fn(run_fn, limit=1):
+  def _run_fn(*args, **kwargs)
+    with threadpoolctl.threadpool_limits(limit=limit):
+      return run_fn(*args, **kwargs)
+  return _run_fn
 
 
 def map_mpi(
@@ -48,6 +56,8 @@ def map_mpi(
   # Create a pool of processes, dispatch the experiments to them, show progress.
   pool = futures.ProcessPoolExecutor(num_processes)
   progress_bar = tqdm.tqdm(total=num_experiments)
+
+  run_fn = thread_limit_run_fn(run_fn, limit=1)
 
   for bsuite_id in pool.map(run_fn, bsuite_ids):
     description = '[Last finished: {}]'.format(bsuite_id)

--- a/bsuite/baselines/utils/pool.py
+++ b/bsuite/baselines/utils/pool.py
@@ -28,7 +28,7 @@ BsuiteId = str
 
 
 def thread_limit_run_fn(run_fn, limit=1):
-  def _run_fn(*args, **kwargs)
+  def _run_fn(*args, **kwargs):
     with threadpoolctl.threadpool_limits(limit=limit):
       return run_fn(*args, **kwargs)
   return _run_fn

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
         'scipy',
         'scikit-image',
         'six',
+        'threadpoolctl',
         'termcolor',
     ],
     extras_require={


### PR DESCRIPTION
Current implementation thrashes the cpu ---> extremely slow running the sweep.

Suggested fix here, but untested --- I get other errors trying to run the default agents:
1) transformed.apply expecting a random key, recent change in JAX, I suspect you need an older version of JAX / need to update this code
2) setup.py doesn't actually work for me out the box:
pip install bsuite[baselines]
ERROR: Could not find a version that satisfies the requirement tensorflow==2.1; extra == "baselines" (from bsuite[baselines]) (from versions: 2.2.0rc1, 2.2.0rc2, 2.2.0rc3, 2.2.0rc4, 2.2.0, 2.3.0rc0, 2.3.0rc1, 2.3.0rc2, 2.3.0)
ERROR: No matching distribution found for tensorflow==2.1; extra == "baselines" (from bsuite[baselines])

I use this in my code interacting with bsuite envs, it tends to speed it up by 10-100x. I suspect something like this might help on internal run scripts too.