### PR TITLE
Default number of ensemble

### DIFF
--- a/bsuite/baselines/jax/boot_dqn/run.py
+++ b/bsuite/baselines/jax/boot_dqn/run.py
@@ -33,7 +33,7 @@ import optax
 
 # Internal imports.
 
-flags.DEFINE_integer('num_ensemble', 1, 'Size of ensemble.')
+flags.DEFINE_integer('num_ensemble', 20, 'Size of ensemble.')
 
 # Experiment flags.
 flags.DEFINE_string(


### PR DESCRIPTION
Hi,

I believe the default value for the number of ensemble should be more than 1. Otherwise the default agent does not solve Deep Sea. I set it to 20 to be consistent with the tensorflow implementation. 

Best.