### PR TITLE
inconsistency fix for stochastic deep sea

### DIFF
--- a/bsuite/environments/deep_sea.py
+++ b/bsuite/environments/deep_sea.py
@@ -118,11 +118,12 @@ class DeepSea(base.Environment):
     action_right = action == self._action_mapping[self._row, self._column]
 
     # Reward calculation
-    if self._column == self._size - 1 and action_right:
+    if self._column == self._size - 1 and action_right \
+            and (self._rng.rand() > 1 / self._size or self._deterministic):
       reward += 1.
       self._denoised_return += 1.
     if not self._deterministic:  # Noisy rewards on the 'end' of chain.
-      if self._row == self._size - 1 and self._column in [0, self._size - 1]:
+      if self._row == self._size - 1 and 0 <= self._column <= self._size - 1:
         reward += self._rng.randn()
 
     # Transition dynamics


### PR DESCRIPTION
1. The description of stochastic sea environment says "adds N(0,1) noise to the end of states of the chain", but in line 125, noisy reward were only added when "column" is either 0 or "_size -1". 
2. The description of stochastic sea environment says "act right with 1 - 1/N moves agent to right", but in line 121, i.e., when agent is at cell "(_size-1, _size-1)" and act right, there is no such stochasticity. 

This pull request fixes these two inconsistency issues. 
Without this pull request fix, expected value under optimal policy is more complicated; with these fixes, 
expected value for optimal policy is simply given by (1-1/N)^N*0.99 + (-0.01 + E[norm(0,1)])*(1-(1-1/N)^N)


