### PR TITLE
Fix radar plot error

### DIFF
--- a/bsuite/experiments/summary_analysis.py
+++ b/bsuite/experiments/summary_analysis.py
@@ -316,12 +316,12 @@ def _radar(
             'Replacing with zero.'.format(len(selected), curr_tag, label))
     values.append(score)
   values = np.maximum(values, 0.05)  # don't let radar collapse to 0.
-  values = np.concatenate((values, [values[0]]))
+  _values = np.concatenate((values, [values[0]]))
 
   angles = np.linspace(0, 2*np.pi, len(all_tags), endpoint=False)
-  angles = np.concatenate((angles, [angles[0]]))
+  _angles = np.concatenate((angles, [angles[0]]))
 
-  ax.plot(angles, values, '-', linewidth=5, label=label,
+  ax.plot(_angles, _values, '-', linewidth=5, label=label,
           c=color, alpha=edge_alpha, zorder=zorder, linestyle=edge_style)
   ax.fill(angles, values, alpha=alpha, color=color, zorder=zorder)
   ax.set_thetagrids(


### PR DESCRIPTION
Without this fix, this tile:
```
#@title overall score as radar plot (double-click to show/hide code)
BSUITE_SCORE = summary_analysis.bsuite_score(DF, SWEEP_VARS)
BSUITE_SUMMARY = summary_analysis.ave_score_by_tag(BSUITE_SCORE, SWEEP_VARS)
BSUITE_SUMMARY
__radar_fig__ = summary_analysis.bsuite_radar_plot(BSUITE_SUMMARY, SWEEP_VARS)
```
of `analysis.ipynb` raises the following error:
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-4-1038e22bb9f6> in <module>
      3 BSUITE_SUMMARY = summary_analysis.ave_score_by_tag(BSUITE_SCORE, SWEEP_VARS)
      4 BSUITE_SUMMARY
----> 5 __radar_fig__ = summary_analysis.bsuite_radar_plot(BSUITE_SUMMARY, SWEEP_VARS)

~/.cache/pypoetry/virtualenvs/bsuite-actor-critic-5C9Ku6ye-py3.8/lib/python3.8/site-packages/bsuite/experiments/summary_analysis.py in bsuite_radar_plot(summary_data, sweep_vars)
    373     sweep_data_ = summary_data.groupby('agent')
    374     for aid, (agent, sweep_df) in enumerate(sweep_data_):
--> 375       _radar(sweep_df, ax, agent, all_tags, color=palette(aid))
    376     if len(sweep_vars) == 1:
    377       label = sweep_vars[0]

~/.cache/pypoetry/virtualenvs/bsuite-actor-critic-5C9Ku6ye-py3.8/lib/python3.8/site-packages/bsuite/experiments/summary_analysis.py in _radar(df, ax, label, all_tags, color, alpha, edge_alpha, zorder, edge_style)
    323           c=color, alpha=edge_alpha, zorder=zorder, linestyle=edge_style)
    324   ax.fill(angles, values, alpha=alpha, color=color, zorder=zorder)
--> 325   ax.set_thetagrids(
    326       angles * 180/np.pi, map(_tag_pretify, all_tags), fontsize=18)
    327 

~/.cache/pypoetry/virtualenvs/bsuite-actor-critic-5C9Ku6ye-py3.8/lib/python3.8/site-packages/matplotlib/projections/polar.py in set_thetagrids(self, angles, labels, fmt, **kwargs)
   1334         self.set_xticks(angles)
   1335         if labels is not None:
-> 1336             self.set_xticklabels(labels)
   1337         elif fmt is not None:
   1338             self.xaxis.set_major_formatter(mticker.FormatStrFormatter(fmt))

~/.cache/pypoetry/virtualenvs/bsuite-actor-critic-5C9Ku6ye-py3.8/lib/python3.8/site-packages/matplotlib/axes/_base.py in wrapper(self, *args, **kwargs)
     71 
     72         def wrapper(self, *args, **kwargs):
---> 73             return get_method(self)(*args, **kwargs)
     74 
     75         wrapper.__module__ = owner.__module__

~/.cache/pypoetry/virtualenvs/bsuite-actor-critic-5C9Ku6ye-py3.8/lib/python3.8/site-packages/matplotlib/_api/deprecation.py in wrapper(*args, **kwargs)
    469                 "parameter will become keyword-only %(removal)s.",
    470                 name=name, obj_type=f"parameter of {func.__name__}()")
--> 471         return func(*args, **kwargs)
    472 
    473     return wrapper

~/.cache/pypoetry/virtualenvs/bsuite-actor-critic-5C9Ku6ye-py3.8/lib/python3.8/site-packages/matplotlib/axis.py in _set_ticklabels(self, labels, fontdict, minor, **kwargs)
   1788         if fontdict is not None:
   1789             kwargs.update(fontdict)
-> 1790         return self.set_ticklabels(labels, minor=minor, **kwargs)
   1791 
   1792     def set_ticks(self, ticks, *, minor=False):

~/.cache/pypoetry/virtualenvs/bsuite-actor-critic-5C9Ku6ye-py3.8/lib/python3.8/site-packages/matplotlib/axis.py in set_ticklabels(self, ticklabels, minor, **kwargs)
   1709             # remove all tick labels, so only error for > 0 ticklabels
   1710             if len(locator.locs) != len(ticklabels) and len(ticklabels) != 0:
-> 1711                 raise ValueError(
   1712                     "The number of FixedLocator locations"
   1713                     f" ({len(locator.locs)}), usually from a call to"

ValueError: The number of FixedLocator locations (8), usually from a call to set_ticks, does not match the number of ticklabels (7).
```

Here are my current dependencies:
```
Package                 Version
----------------------- -------------------
absl-py                 0.13.0
anyio                   3.1.0
appdirs                 1.4.4
argon2-cffi             20.1.0
astunparse              1.6.3
async-generator         1.10
attrs                   21.2.0
Babel                   2.9.1
backcall                0.2.0
black                   21.6b0
bleach                  3.3.0
bsuite                  0.3.5
cachetools              4.2.2
certifi                 2021.5.30
cffi                    1.14.5
chardet                 4.0.0
chex                    0.0.7
click                   8.0.1
cloudpickle             1.6.0
colorama                0.4.4
cycler                  0.10.0
decorator               4.4.2
defusedxml              0.7.1
descartes               1.1.0
dm-env                  1.4
dm-haiku                0.0.4
dm-tree                 0.1.6
entrypoints             0.3
filelock                3.0.12
flatbuffers             1.12
frozendict              2.0.2
gast                    0.4.0
google-auth             1.31.0
google-auth-oauthlib    0.4.4
google-pasta            0.2.0
grpcio                  1.34.1
gym                     0.18.3
h5py                    3.1.0
halo                    0.0.31
huggingface-hub         0.0.8
idna                    2.10
imageio                 2.9.0
ipdb                    0.13.9
ipykernel               5.5.5
ipython                 7.24.1
ipython-genutils        0.2.0
jax                     0.2.14
jaxlib                  0.1.65+cuda112
jedi                    0.18.0
Jinja2                  3.0.1
joblib                  1.0.1
json5                   0.9.5
jsonschema              3.2.0
jupyter-client          6.2.0
jupyter-core            4.7.1
jupyter-server          1.8.0
jupyterlab              3.0.16
jupyterlab-pygments     0.1.2
jupyterlab-server       2.6.0
keras-nightly           2.5.0.dev2021032900
Keras-Preprocessing     1.1.2
kiwisolver              1.3.1
log-symbols             0.0.14
Markdown                3.3.4
MarkupSafe              2.0.1
matplotlib              3.4.2
matplotlib-inline       0.1.2
mistune                 0.8.4
mizani                  0.7.3
mypy-extensions         0.4.3
nbclassic               0.3.1
nbclient                0.5.3
nbconvert               6.0.7
nbformat                5.1.3
nest-asyncio            1.5.1
networkx                2.5.1
notebook                6.4.0
numpy                   1.19.5
oauthlib                3.1.1
opt-einsum              3.3.0
optax                   0.0.6
packaging               20.9
palettable              3.3.0
pandas                  1.2.4
pandocfilters           1.4.3
parso                   0.8.2
pathspec                0.8.1
patsy                   0.5.1
pexpect                 4.8.0
pickleshare             0.7.5
Pillow                  8.2.0
pip                     21.0.1
plotnine                0.8.0
prometheus-client       0.11.0
prompt-toolkit          3.0.18
protobuf                3.17.3
ptyprocess              0.7.0
pyasn1                  0.4.8
pyasn1-modules          0.2.8
pycparser               2.20
pyglet                  1.5.15
Pygments                2.9.0
pyparsing               2.4.7
pyrsistent              0.17.3
python-dateutil         2.8.1
pytz                    2021.1
PyWavelets              1.1.1
pyzmq                   22.1.0
redis                   3.5.3
regex                   2021.4.4
requests                2.25.1
requests-oauthlib       1.3.0
rlax                    0.0.3
rsa                     4.7.2
sacremoses              0.0.45
scikit-image            0.18.1
scipy                   1.6.3
Send2Trash              1.5.0
setuptools              54.1.2
six                     1.15.0
sniffio                 1.2.0
spinners                0.0.24
statsmodels             0.12.2
tabulate                0.8.9
tensorboard             2.5.0
tensorboard-data-server 0.6.1
tensorboard-plugin-wit  1.8.0
tensorflow              2.5.0
tensorflow-estimator    2.5.0
termcolor               1.1.0
terminado               0.10.1
testpath                0.5.0
tifffile                2021.6.14
tokenizers              0.10.3
toml                    0.10.2
toolz                   0.11.1
tornado                 6.1
tqdm                    4.61.1
traitlets               5.0.5
transformers            4.6.1
typing-extensions       3.7.4.3
urllib3                 1.26.5
wcwidth                 0.2.5
webencodings            0.5.1
websocket-client        1.1.0
Werkzeug                2.0.1
wheel                   0.36.2
wrapt                   1.12.1
```