### PR TITLE
_total_steps assignment position bug

### DIFF
--- a/bsuite/baselines/tf/boot_dqn/agent.py
+++ b/bsuite/baselines/tf/boot_dqn/agent.py
@@ -120,7 +120,6 @@ class BootstrappedDqn(base.Agent):
 
       loss = tf.reduce_mean(tf.stack(losses))
       gradients = tape.gradient(loss, variables)
-    self._total_steps.assign_add(1)
     self._optimizer.apply(gradients, variables)
 
     # Periodically update the target network.
@@ -132,6 +131,7 @@ class BootstrappedDqn(base.Agent):
 
   def select_action(self, timestep: dm_env.TimeStep) -> base.Action:
     """Select values via Thompson sampling, then use epsilon-greedy policy."""
+    self._total_steps.assign_add(1)
     if self._rng.rand() < self._epsilon_fn(self._total_steps.numpy()):
       return self._rng.randint(self._num_actions)
 


### PR DESCRIPTION
The _total_steps should be increased after the agent takes an action, as in the jax implementation, or during the update function call, as for DQN. If the assignment is done after computing the gradient, as in the current implementation, the agent will not be trained for values of the sgd_period values higher than one.