### PR TITLE
Convert `np.int -> np.int32` since `np.int` is deprecated

### DIFF
--- a/bsuite/baselines/utils/sequence_test.py
+++ b/bsuite/baselines/utils/sequence_test.py
@@ -32,7 +32,7 @@ class BufferTest(absltest.TestCase):
     obs_shape = (3, 3)
     buffer = sequence.Buffer(
         obs_spec=specs.Array(obs_shape, dtype=np.float),
-        action_spec=specs.Array((), dtype=np.int),
+        action_spec=specs.Array((), dtype=np.int32),
         max_sequence_length=max_sequence_length)
     dummy_step = dm_env.transition(observation=np.zeros(obs_shape), reward=0.)
 

--- a/bsuite/environments/cartpole.py
+++ b/bsuite/environments/cartpole.py
@@ -159,7 +159,7 @@ class Cartpole(base.Environment):
     raise NotImplementedError('This environment implements its own auto-reset.')
 
   def action_spec(self):
-    return specs.DiscreteArray(dtype=np.int, num_values=3, name='action')
+    return specs.DiscreteArray(dtype=np.int32, num_values=3, name='action')
 
   def observation_spec(self):
     return specs.Array(shape=(1, 6), dtype=np.float32, name='state')

--- a/bsuite/environments/catch.py
+++ b/bsuite/environments/catch.py
@@ -104,7 +104,7 @@ class Catch(base.Environment):
   def action_spec(self) -> specs.DiscreteArray:
     """Returns the action spec."""
     return specs.DiscreteArray(
-        dtype=np.int, num_values=len(_ACTIONS), name="action")
+        dtype=np.int32, num_values=len(_ACTIONS), name="action")
 
   def _observation(self) -> np.ndarray:
     self._board.fill(0.)

--- a/bsuite/experiments/cartpole_swingup/cartpole_swingup.py
+++ b/bsuite/experiments/cartpole_swingup/cartpole_swingup.py
@@ -129,7 +129,7 @@ class CartpoleSwingup(base.Environment):
     raise NotImplementedError('This environment implements its own auto-reset.')
 
   def action_spec(self):
-    return specs.DiscreteArray(dtype=np.int, num_values=3, name='action')
+    return specs.DiscreteArray(dtype=np.int32, num_values=3, name='action')
 
   def observation_spec(self):
     return specs.Array(shape=(1, 8), dtype=np.float32, name='state')


### PR DESCRIPTION
It seems like `np.int` has been deprecated in favour of either `int` or `np.int16/32/64/128` [in numpy 1.20](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated).

This PR fixes that error. The exact stack trace fo the error in deployed code is [here](https://github.com/Farama-Foundation/Shimmy/actions/runs/4295142414/jobs/7486881307#step:4:890).