### PR TITLE
Replace imp with importlib for Python 3.12 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,17 @@
 # ============================================================================
 """Install script for setuptools."""
 
-import imp
+import sys
+import importlib
 
 import setuptools
+
+def load_source(module_name, path_to_file):
+    spec = importlib.util.spec_from_file_location(module_name, path_to_file)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    sys.modules[module_name] = module
+    return module
 
 # Additional requirements for TensorFlow baselines, excluding OpenAI & Dopamine.
 # See baselines/README.md for more information.
@@ -67,7 +75,7 @@ setuptools.setup(
     author='DeepMind',
     author_email='dm-bsuite-eng+os@google.com',
     license='Apache License, Version 2.0',
-    version=imp.load_source('_metadata', 'bsuite/_metadata.py').__version__,
+    version=load_source('_metadata', 'bsuite/_metadata.py').__version__,
     keywords='reinforcement-learning python machine-learning',
     packages=setuptools.find_packages(),
     install_requires=[


### PR DESCRIPTION
I've been trying to use [Pax](https://github.com/ucl-dark/pax/) on Python 3.12 and I can't because `bsuite` doesn't support Python 3.12. This should fix that. 